### PR TITLE
fix(graph): page overflow with graph

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -238,11 +238,13 @@ const TopCountriesSection = () => {
           Evolution de l'élevage du saumon par pays
         </h3>
 
-        <DashboardChart
-          data={mapData.data}
-          layout={mapData.layout}
-          id="evolution-map"
-        />
+        <div className="flex md:justify-center min-h-[450px] overflow-y-auto">
+          <DashboardChart
+            data={mapData.data}
+            layout={mapData.layout}
+            id="evolution-map"
+          />
+        </div>
       </div>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -217,7 +217,7 @@ const BusinessSection = () => {
           connaît depuis quelques décennies une hyper-croissance à l’échelle
           globale.
         </p>
-        <div className="flex justify-center">
+        <div className="flex md:justify-center min-h-[450px] overflow-y-auto bg-white">
           <Plot data={plot.data} layout={plot.layout} />
         </div>
       </div>

--- a/src/components/JoinBlock.tsx
+++ b/src/components/JoinBlock.tsx
@@ -67,7 +67,7 @@ const IntroBlock = ({
             saumon au monde, porte une responsabilité particulière dans
             l'orientation des pratiques.
           </p>
-          <div className="flex justify-center">
+          <div className="flex lg:justify-center min-h-[300px] overflow-y-auto bg-white">
             <Plot data={plot.data} layout={plot.layout} />
           </div>
         </div>


### PR DESCRIPTION
# Description & Technical Solution

The storytelling page graphics are 500px wide and create horizontal scrolling on small screens

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] Already rebased against main branch.

# Screenshots

<img width="675" alt="Capture d’écran 2024-05-15 à 13 58 46" src="https://github.com/dataforgoodfr/12_pinkbombs_app/assets/5670642/ef3d17c4-5fb1-4229-a6c1-8680b135cc46">

