### PR TITLE
feat: add links to download plotly screenshots

### DIFF
--- a/messages/en/pages/dashboard.json
+++ b/messages/en/pages/dashboard.json
@@ -176,7 +176,8 @@
             "content": "<p>Some producers achieve much lower mortality rates thanks to better practices but also local legislation. Please note: these figures only take into account mortality at sea. Mortality in fresh water bodies is close to 30% (Multiexport reports)</p>",
             "meta": {
               "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/mortality_rates_4.4.csv.zip",
-              "dataArtifact": "mortality_rates_4.4.csv.zip"
+              "dataArtifact": "mortality_rates_4.4.csv.zip",
+              "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/mortality_rates_4.4_fr.png"
             }
           }
         }

--- a/messages/en/pages/dashboard.json
+++ b/messages/en/pages/dashboard.json
@@ -21,7 +21,8 @@
             "content": "<p>Salmon production has experienced unprecedented growth.</p><p>Nearly nonexistent 30 years ago, it surged to three million tons of salmon in 2021, equivalent to the farming and slaughtering of one billion salmon.</p>",
             "source": "",
             "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/hyper_growth_salmon_farming_1.2.csv.zip",
-            "artifact": "hyper_growth_salmon_farming_1.2.csv.zip"
+            "artifact": "hyper_growth_salmon_farming_1.2.csv.zip",
+            "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/hyper_growth_salmon_farming_1.2.png"
           },
           "top-10": {
             "title": "Main countries producing farmed salmon",
@@ -29,18 +30,21 @@
             "source": "",
             "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/top_10_countries_producing_1.3.csv.zip",
             "artifact": "top_10_countries_producing_1.3.csv.zip",
+            "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/top_10_countries_producing_1.3.png",
             "subblock": {
               "title": "Salmon farming evolution by country",
               "source": "https://www.fao.org/fisheryen/collection/aquaculture?lang=en",
               "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/evolution_salmon_farming_country_iso_1.4.csv.zip",
-              "artifact": "evolution_salmon_farming_country_iso_1.4.csv.zip"
+              "artifact": "evolution_salmon_farming_country_iso_1.4.csv.zip",
+              "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/tevolution_salmon_farming_country_iso_1.4.png"
             }
           },
           "intro-consumption": {
             "title": "Main countries consuming salmon",
             "content": "<p>The increase in salmon production results from an increase in the consumption of this fish, whose flesh is highly valued. In 2021, the United States were the largest consumers of salmon, with an <a href=\"/about#macro-consumption-section\">apparent consumption</a> approaching one million tons, followed by Russia and Japan, with consumption around 500,000 tons. European countries follow this podium, with France, the UK, Germany and Italy being large consumers of salmon in 2021. Consumption in Western countries is around 3 to 4 kilos per capita, while emerging countries such as Brazil have very low per capita consumption.<p>",
             "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/top_15_countries_consuming_1.5.csv.zip",
-            "artifact": "top_15_countries_consuming_1.5.csv.zip"
+            "artifact": "top_15_countries_consuming_1.5.csv.zip",
+            "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/top_15_countries_consuming_1.5.png"
           }
         }
       },
@@ -52,14 +56,16 @@
             "content": "<p>Small artisanal salmon farms have given way to industrial aquaculture.</p><p>In a few decades, the market has become dominated by a handful of multinational corporations.</p><p>Mowi, formerly known as Marine Harvest, is the leader in the sector. The company operates in 25 countries.</p>",
             "source": "",
             "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/top_10_companies_producing_2.1.csv.zip",
-            "artifact": "top_10_companies_producing_2.1.csv.zip"
+            "artifact": "top_10_companies_producing_2.1.csv.zip",
+            "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/top_10_companies_producing_2.1.png"
           },
           "top-land": {
             "title": "The new threat: on land plants",
             "mainContent": "<p>In 2021, the theoretical combined production capacity of land-based salmon farms amounted to 2.5 million tons, nearly equaling the global production of salmon in marine farms (2.7 million tons).</p>",
             "content": "<p>Land-based farms use RAS technology (Recirculating Aquaculture Systems) in fully enclosed tanks. Whilst, this approach to salmon farming gives control over the impact on biodiversity and the local environment (limited disease contamination, rejection of feces and salmon escapes), it also requires large amount of fresh water and is very energy-hungry, as it aims to recreate very precisely the natural conditions found in the sea.</p><p>As a result, the carbon footprint of salmon produced on land is higher than salmon produced in marine farms.</p><p>In order to make such farms profitable, the fish density can be 3 times higher than in marine farms. And there has been a small number of accidents where large number of fish died as a result of inadequate water conditions and a fire at a plant in Denmark.</p>",
             "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/top_10_ras_companies_2.3.csv.zip",
-            "artifact": "top_10_ras_companies_2.3.csv.zip"
+            "artifact": "top_10_ras_companies_2.3.csv.zip",
+            "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/top_10_ras_companies_2.3.png"
           },
           "future-land-based": {
             "title": "The future of land-based aquaculture farms",

--- a/messages/en/pages/dashboard.json
+++ b/messages/en/pages/dashboard.json
@@ -13,7 +13,8 @@
             "content": "<p>The Atlantic salmon was added to the IUCN Red List of Threatened Species in December 2023.</p><p>This is largely due to overfishing, habitat degradation, particularly caused by dams blocking migratory routes, as well as climate change altering their environments, impacting their growth and survival rates.</p>",
             "source": "",
             "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/discrease_wild_salmon_1.1.csv.zip",
-            "artifact": "discrease_wild_salmon_1.1.csv.zip"
+            "artifact": "discrease_wild_salmon_1.1.csv.zip",
+            "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/discrease_wild_salmon_1.1.png"
           },
           "hyper-growth": {
             "title": "Hyper-growth in salmon farming",
@@ -177,7 +178,7 @@
             "meta": {
               "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/mortality_rates_4.4.csv.zip",
               "dataArtifact": "mortality_rates_4.4.csv.zip",
-              "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/mortality_rates_4.4_fr.png"
+              "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/mortality_rates_4.4.png"
             }
           }
         }

--- a/messages/en/pages/story.json
+++ b/messages/en/pages/story.json
@@ -54,6 +54,7 @@
       "source": "https://www.fao.org/fishery/en/collection/aquaculture?lang=en",
       "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/final-changes/download/csv/numbers_salmons_farmed_1.0.csv.zip",
       "artifact": "numbers_salmons_farmed_1.0_fr.csv.zip",
+      "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/numbers_salmons_farmed_1.0.png",
       "link": "We act"
     }
   }

--- a/messages/fr/pages/dashboard.json
+++ b/messages/fr/pages/dashboard.json
@@ -13,7 +13,8 @@
             "content": "<p>Le saumon atlantique est inscrit sur la Liste rouge de l'UICN des espèces menacées en décembre 2023.</p><p>Cela est dû en grande partie à la surpêche, à la dégradation de l'habitat, notamment due aux barrages bloquant les routes migratoires, mais aussi au changement climatique qui modifie leurs environnements, impactant leurs taux de croissance et de survie.</p>",
             "source": "anglais",
             "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/discrease_wild_salmon_1.1_fr.csv.zip",
-            "artifact": "discrease_wild_salmon_1.1_fr.csv.zip"
+            "artifact": "discrease_wild_salmon_1.1_fr.csv.zip",
+            "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/discrease_wild_salmon_1.1_fr.png"
           },
           "hyper-growth": {
             "title": "Hyper-croissance de l’élevage du saumon",
@@ -172,7 +173,8 @@
             "content": "<p>Certains producteurs atteignent des taux de mortalité bien inférieurs grâce à de meilleures pratiques mais aussi à la législation locale. Attention : ces chiffres ne prennent en compte que la mortalité en mer. La mortalité dans les plans d'eau douce est proche de 30% (rapports Multiexport)</p>",
             "meta": {
               "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/mortality_rates_4.4_fr.csv.zip",
-              "dataArtifact": "mortality_rates_4.4_fr.csv.zip"
+              "dataArtifact": "mortality_rates_4.4_fr.csv.zip",
+              "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/mortality_rates_4.4_fr.png"
             }
           }
         }

--- a/messages/fr/pages/dashboard.json
+++ b/messages/fr/pages/dashboard.json
@@ -21,7 +21,8 @@
             "content": "<p>La production de saumon a connu une croissance sans précédent.</p><p>Quasi inexistante il y a 30 ans, elle a bondi à trois millions de tonnes de saumon en 2021, soit l’équivalent de l’élevage et de l’abattage d’un milliard de saumons.</p>",
             "source": "anglais",
             "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/hyper_growth_salmon_farming_1.2_fr.csv.zip",
-            "artifact": "hyper_growth_salmon_farming_1.2_fr.csv.zip"
+            "artifact": "hyper_growth_salmon_farming_1.2_fr.csv.zip",
+            "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/hyper_growth_salmon_farming_1.2_fr.png"
           },
           "top-10": {
             "title": "Principaux pays producteurs de saumon d'élevage",
@@ -29,18 +30,21 @@
             "source": "anglais",
             "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/top_10_countries_producing_1.3_fr.csv.zip",
             "artifact": "top_10_countries_producing_1.3_fr.csv.zip",
+            "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/top_10_countries_producing_1.3_fr.png",
             "subblock": {
               "title": "Evolution de l'élevage du saumon par pays",
               "source": "https://www.fao.org/fishery/fr/collection/aquaculture?lang=fr",
               "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/evolution_salmon_farming_country_iso_1.4_fr.csv.zip",
-              "artifact": "evolution_salmon_farming_country_iso_1.4_fr.csv.zip"
+              "artifact": "evolution_salmon_farming_country_iso_1.4_fr.csv.zip",
+              "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/tevolution_salmon_farming_country_iso_1.4_fr.png"
             }
           },
           "intro-consumption": {
             "title": "Les plus gros consommateurs de saumon",
             "content": "<p>La hausse de la production de saumons résulte d’une augmentation de la consommation de ce poisson, dont la chair est très appréciée. En 2021, les États-unis étaient les plus gros consommateurs de saumon, avec une <a href=\"/about#macro-consumption-section\">consommation apparente</a> s’approchant du million de tonnes, suivis par la Russie et le Japon dont la consommation est d’environ 500,000 tonnes. Les pays européens suivent ensuite, la France étant en 2021 le 4ème pays le plus consommateur de saumon au monde. La consommation des pays occidentaux se situe aux alentours de 3 à 4 kilos de saumon par habitant, tandis que des pays émergents comme le Brésil présentent des consommations par habitant très faibles.<p>",
             "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/top_15_countries_consuming_1.5_fr.csv.zip",
-            "artifact": "top_15_countries_consuming_1.5_fr.csv.zip"
+            "artifact": "top_15_countries_consuming_1.5_fr.csv.zip",
+            "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/top_15_countries_consuming_1.5_fr.png"
           }
         }
       },
@@ -52,14 +56,16 @@
             "content": "<p>Les petites fermes salmonicoles artisanales ont cédé la place à l’aquaculture industrielle.</p><p>En quelques décennies, le marché est devenu dominé par une poignée de multinationales.</p><p>Mowi, anciennement Marine Harvest, est leader du secteur. L'entreprise est présente dans 25 pays.</p>",
             "source": "anglais",
             "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/top_10_companies_producing_2.1_fr.csv.zip",
-            "artifact": "top_10_companies_producing_2.1_fr.csv.zip"
+            "artifact": "top_10_companies_producing_2.1_fr.csv.zip",
+            "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/top_10_companies_producing_2.1_fr.png"
           },
           "top-land": {
             "title": "La nouvelle menace : sur fermes aquacoles terrestres",
             "mainContent": "<p>En 2021, la capacité de production théorique combinée des élevages terrestres de saumon s’élève à 2,5 millions de tonnes, soit presque autant que la production mondiale de saumon dans les élevages marins (2,7 millions de tonnes).</p>",
             "content": "<p>Les fermes terrestres utilisent la technologie RAS (Recycled Aquaculture Systems) dans des réservoirs entièrement fermés. Si cette approche de l'élevage du saumon permet de limiter l'impact sur la biodiversité et l'environnement local (contamination limitée par les maladies, rejet des excréments et des évasions de saumons), elle nécessite également de grandes quantités d'eau douce et est très gourmande en énergie, car elle vise à recréer très précisément les conditions de l’habitat naturel des saumons.</p><p>En conséquence, l’empreinte carbone du saumon produit sur terre est plus élevée que celle du saumon produit dans les fermes marines. Afin de rentabiliser de telles fermes, la densité de poissons peut être 3 fois plus élevée que dans les fermes marines.</p><p>La technologie n’est pas encore totalement maîtrisée : actuellement, aucune usine en fonctionnement ne produit plus de 5 000 tonnes et les incidents techniques sont fréquents.</p><p>Une usine au Danemark en a subi cinq, résultant de défaillances techniques (pollution au chlorure de fer dans le fjord, incendie complet de son usine, engendrant pollution de l’air et de l’eau).</p>",
             "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/top_10_ras_companies_2.3_fr.csv.zip",
-            "artifact": "top_10_ras_companies_2.3_fr.csv.zip"
+            "artifact": "top_10_ras_companies_2.3_fr.csv.zip",
+            "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/top_10_ras_companies_2.3_fr.png"
           },
           "future-land-based": {
             "title": "Le futur des fermes aquacoles terrestres",

--- a/messages/fr/pages/story.json
+++ b/messages/fr/pages/story.json
@@ -54,6 +54,7 @@
       "source": "https://www.fao.org/fishery/fr/collection/aquaculture",
       "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/numbers_salmons_farmed_1.0_fr.csv.zip",
       "artifact": "numbers_salmons_farmed_1.0_fr.csv.zip",
+      "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/numbers_salmons_farmed_1.0_fr.png",
       "link": "On agit"
     }
   }

--- a/src/app/[locale]/dashboard/dashboard.tsx
+++ b/src/app/[locale]/dashboard/dashboard.tsx
@@ -272,6 +272,11 @@ const SalmonFarmingSection = () => {
             link: t("sections.intro.blocks.hyper-growth.data"),
             artifact: t("sections.intro.blocks.hyper-growth.artifact"),
           },
+          {
+            type: "image",
+            isBlank: true,
+            link: t("sections.intro.blocks.hyper-growth.image"),
+          },
         ],
       }}
       hasChart
@@ -305,6 +310,11 @@ const TopCountriesSection = () => {
               link: t("sections.intro.blocks.top-10.data"),
               artifact: t("sections.intro.blocks.top-10.artifact"),
             },
+            {
+              type: "image",
+              isBlank: true,
+              link: t("sections.intro.blocks.top-10.image"),
+            },
           ],
         }}
         hasChart
@@ -332,6 +342,11 @@ const TopCountriesSection = () => {
               link: t("sections.intro.blocks.top-10.subblock.data"),
               artifact: t("sections.intro.blocks.top-10.subblock.artifact"),
             },
+            {
+              type: "image",
+              isBlank: true,
+              link: t("sections.intro.blocks.top-10.subblock.image"),
+            },
           ]}
         />
       </div>
@@ -357,6 +372,11 @@ const SalmonConsumptionSection = () => {
             type: "data",
             link: t("sections.intro.blocks.intro-consumption.data"),
             artifact: t("sections.intro.blocks.intro-consumption.artifact"),
+          },
+          {
+            type: "image",
+            isBlank: true,
+            link: t("sections.intro.blocks.intro-consumption.image"),
           },
         ],
       }}
@@ -389,6 +409,11 @@ const MainProductionSection = () => {
             type: "data",
             link: t("sections.company.blocks.top-comp.data"),
             artifact: t("sections.company.blocks.top-comp.artifact"),
+          },
+          {
+            type: "image",
+            isBlank: true,
+            link: t("sections.company.blocks.top-comp.image"),
           },
         ],
       }}
@@ -423,7 +448,12 @@ const LandPlantsSection = () => {
             {
               type: "data",
               link: t("sections.company.blocks.top-comp.data"),
-              artifact: t("sections.company.blocks.top-comp.artifact"),
+              artifact: t("sections.company.blocks.top-land.artifact"),
+            },
+            {
+              type: "image",
+              isBlank: true,
+              link: t("sections.company.blocks.top-land.image"),
             },
           ],
         }}

--- a/src/app/[locale]/dashboard/dashboard.tsx
+++ b/src/app/[locale]/dashboard/dashboard.tsx
@@ -702,6 +702,11 @@ const MortalityRateSection = () => {
             link: t("sections.animals.blocks.mortality-rates.meta.data"),
             artifact: t("sections.animals.blocks.mortality-rates.meta.dataArtifact"),
           },
+          {
+            type: "image",
+            isBlank: true,
+            link: t("sections.animals.blocks.mortality-rates.meta.image"),
+          },
         ],
       }}
     />

--- a/src/app/[locale]/dashboard/dashboard.tsx
+++ b/src/app/[locale]/dashboard/dashboard.tsx
@@ -235,6 +235,11 @@ const SalmonCollapseSection = () => {
             link: t("sections.intro.blocks.salmon-collapse.data"),
             artifact: t("sections.intro.blocks.salmon-collapse.artifact"),
           },
+          {
+            type: "image",
+            isBlank: true,
+            link: t("sections.intro.blocks.salmon-collapse.image"),
+          },
         ],
       }}
       hasChart

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -211,6 +211,11 @@ const BusinessSection = () => {
               link: t("industry.data"),
               artifact: t("industry.artifact"),
             },
+            {
+              type: "image",
+              isBlank: true,
+              link: t("industry.image"),
+            },
           ]}
         />
         <div className="flex justify-center">


### PR DESCRIPTION
Modified dashboard and story pages to add the "Image" link below the plotly graphs to download the screenshots.
Note that the links will work once the PR on the other repo is accepted. 
https://github.com/dataforgoodfr/12_pinkbombs/pull/17