### PR TITLE
fix change alternatives to food choices

### DIFF
--- a/messages/en/components.json
+++ b/messages/en/components.json
@@ -34,9 +34,9 @@
         "intro": "What we choose to eat, sell, and produce has different impacts on the planet, people, and animals.",
         "content": "<p>France, being among the top 4 largest consumers of salmon in the world, bears a particular responsibility in influencing these choices.</p>",
         "pdf": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/Table_food_choices_simplified_en.pdf",
-        "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/alternatives_text_7.csv.zip",
-        "artifact": "alternatives_text_7.csv.zip",
-        "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/alternatives_7.png"
+        "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/foodchoices_text_7.csv.zip",
+        "artifact": "foodchoices_text_7.csv.zip",
+        "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/foodchoices_7.png"
       }
     },
     "metaChart": {

--- a/messages/fr/components.json
+++ b/messages/fr/components.json
@@ -34,9 +34,9 @@
         "intro": "Ce que nous choisissons de manger, de vendre et de produire à des impacts différents sur la planète, les gens et les animaux.",
         "content": "<p>La France, située dans le top 4 des plus grands consommateurs de saumons au monde, porte une responsabilité particulière dans l'orientation de ces choix.</p>",
         "pdf": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/Tableau_des_choix_alimentaires_simplifiee.pdf",
-        "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/alternatives_text_7_fr.csv.zip",
-        "artifact": "alternatives_text_7.csv.zip",
-        "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/alternatives_7_fr.png"
+        "data": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/csv/foodchoices_text_7_fr.csv.zip",
+        "artifact": "foodchoices_text_7.csv.zip",
+        "image": "https://raw.githubusercontent.com/dataforgoodfr/12_pinkbombs/main/download/graphs_image/foodchoices_7_fr.png"
       }
     },
     "metaChart": {


### PR DESCRIPTION
Changements pour ce ticket trello 
https://trello.com/c/Q3WRa2Ho

marqué sur la liste https://docs.google.com/document/d/1YmcQnh-POfcqkVxUWRDf5YMNw4_vf9xLh6cCusBjbVY/edit?usp=sharing

Le noms des fichiers csv.zip et des fichiers png ont ete change sur le repo 12_pinkbombs (directement sur main). Donc le telechargment de ces fichiers ne marche plus sur Staging jusqu'a ce que cette branche soit mergee. 